### PR TITLE
feat: Add OpenReplay V2 session recording integration

### DIFF
--- a/.github/workflows/deploy-v2-prod.yaml
+++ b/.github/workflows/deploy-v2-prod.yaml
@@ -1,0 +1,295 @@
+# V2 Production Deployment Workflow for code-server
+# Builds code-server with qBraid patches and uploads .deb packages to GCS
+#
+# Uses Workload Identity Federation for GCP authentication (no service account keys)
+# Uploads to: gs://qbraid-code-server/production/release-packages/
+
+name: Deploy V2 Prod - code-server
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 0.0.1). Will be prefixed with qbraid-'
+        type: string
+        required: true
+        default: '0.0.1'
+      skip_github_release:
+        description: 'Skip creating GitHub release (only upload to GCS)'
+        type: boolean
+        required: false
+        default: true
+
+env:
+  GCP_PROJECT_ID: qbraid-prod
+  GCP_REGION: us-central1
+  GCS_BUCKET: qbraid-code-server
+  WORKLOAD_IDENTITY_PROVIDER: projects/314301605548/locations/global/workloadIdentityPools/github-actions-v2-pool/providers/github-oidc-v2
+  SERVICE_ACCOUNT: github-actions-v2-deploy@qbraid-prod.iam.gserviceaccount.com
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Build the npm package with version modifications
+  npm-version:
+    name: Prepare npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply patches and build
+        run: npm run build
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Building version: ${VERSION}"
+
+      - name: Update version in package.json
+        run: |
+          npm version --no-git-tag-version "${{ steps.version.outputs.version }}"
+
+      - name: Update version in product.json
+        run: |
+          tmp=$(mktemp)
+          jq ".codeServerVersion = \"${{ steps.version.outputs.version }}\"" lib/vscode/product.json > "$tmp"
+          mv "$tmp" lib/vscode/product.json
+
+      - name: Create release package
+        run: npm run release
+
+      - name: Package release
+        run: tar -czf package.tar.gz release
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-package
+          path: ./package.tar.gz
+          retention-days: 1
+
+  # Build Linux packages (amd64 only for now - our primary target)
+  package-linux-amd64:
+    name: Build Linux amd64
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: npm-version
+    container: "python:3.10-slim-bookworm"
+    env:
+      npm_config_arch: x64
+      PKG_ARCH: amd64
+      npm_config_build_from_source: true
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            libx11-dev \
+            libxkbfile-dev \
+            libsecret-1-dev \
+            libkrb5-dev \
+            ca-certificates \
+            curl \
+            wget \
+            rsync \
+            git \
+            jq
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install nfpm
+        run: |
+          mkdir -p ~/.local/bin
+          curl -sSfL https://github.com/goreleaser/nfpm/releases/download/v2.3.1/nfpm_2.3.1_Linux_x86_64.tar.gz | tar -C ~/.local/bin -zxv nfpm
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - run: SKIP_SUBMODULE_DEPS=1 npm ci
+
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-release-package
+
+      - name: Extract and build standalone
+        run: |
+          tar -xzf package.tar.gz
+          npm run release:standalone
+
+      - name: Build .deb package
+        env:
+          VERSION: ${{ needs.npm-version.outputs.version }}
+        run: npm run package $PKG_ARCH
+
+      - name: List built packages
+        run: ls -la ./release-packages/
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-amd64-packages
+          path: ./release-packages/*.deb
+          retention-days: 7
+
+  # Upload to GCS using Workload Identity Federation
+  upload-to-gcs:
+    name: Upload to GCS (V2 Prod)
+    runs-on: ubuntu-latest
+    needs: [npm-version, package-linux-amd64]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-amd64-packages
+          path: ./release-packages/
+
+      - name: List packages to upload
+        run: |
+          echo "Packages to upload:"
+          ls -la ./release-packages/
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Upload .deb files to GCS
+        run: |
+          VERSION="${{ needs.npm-version.outputs.version }}"
+          
+          echo "Uploading packages to gs://${{ env.GCS_BUCKET }}/production/release-packages/"
+          
+          for file in ./release-packages/*.deb; do
+            if [ -f "$file" ]; then
+              filename=$(basename "$file")
+              echo "Uploading: $filename"
+              gsutil cp "$file" "gs://${{ env.GCS_BUCKET }}/production/release-packages/$filename"
+            fi
+          done
+          
+          echo "Upload complete!"
+          echo ""
+          echo "Uploaded files:"
+          gsutil ls "gs://${{ env.GCS_BUCKET }}/production/release-packages/" | grep -E "\.deb$" | tail -10
+
+      - name: Output download URLs
+        run: |
+          VERSION="${{ needs.npm-version.outputs.version }}"
+          echo "## Package URLs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Download the packages from GCS:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          for file in ./release-packages/*.deb; do
+            if [ -f "$file" ]; then
+              filename=$(basename "$file")
+              echo "- \`gs://${{ env.GCS_BUCKET }}/production/release-packages/$filename\`" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+  # Optional: Create GitHub release
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [npm-version, package-linux-amd64]
+    if: ${{ inputs.skip_github_release != true }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-amd64-packages
+          path: ./release-packages/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.npm-version.outputs.version }}
+          name: qBraid code-server v${{ needs.npm-version.outputs.version }}
+          draft: true
+          prerelease: false
+          files: ./release-packages/*
+          body: |
+            ## qBraid code-server v${{ needs.npm-version.outputs.version }}
+            
+            Custom code-server build with qBraid patches including:
+            - OpenReplay V2 session recording integration
+            - qBraid branding
+            
+            ### Installation
+            
+            Download the `.deb` package for your architecture and install:
+            ```bash
+            sudo dpkg -i code-server_${{ needs.npm-version.outputs.version }}_amd64.deb
+            ```
+            
+            ### OpenReplay Configuration
+            
+            Set the following environment variables before starting code-server:
+            - `OPENREPLAY_PROJECT_KEY`: Your OpenReplay project key
+            - `JUPYTERHUB_USER` or `USER_EMAIL`: User identifier for session tracking
+
+  # Summary job
+  summary:
+    name: Build Summary
+    runs-on: ubuntu-latest
+    needs: [npm-version, package-linux-amd64, upload-to-gcs]
+    if: always()
+    steps:
+      - name: Generate summary
+        run: |
+          echo "## V2 Production Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ needs.npm-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Prepare npm package | ${{ needs.npm-version.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build Linux amd64 | ${{ needs.package-linux-amd64.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Upload to GCS | ${{ needs.upload-to-gcs.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### GCS Location" >> $GITHUB_STEP_SUMMARY
+          echo "\`gs://qbraid-code-server/production/release-packages/\`" >> $GITHUB_STEP_SUMMARY

--- a/patches/openreplay.diff
+++ b/patches/openreplay.diff
@@ -1,0 +1,166 @@
+Add OpenReplay session recording integration
+
+Integrates OpenReplay tracker into code-server for session recording
+and replay in the qBraid Lab VS Code environment.
+
+1. Add OpenReplay initialization to the client startup
+2. Inject OpenReplay script into workbench HTML templates
+3. Configure tracker with proper settings for CSS rendering
+
+Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/client.ts
++++ code-server/lib/vscode/src/vs/workbench/browser/client.ts
+@@ -1,5 +1,10 @@
+ import { Disposable } from "../../base/common/lifecycle.js";
+ 
++// OpenReplay configuration - these can be overridden via environment
++const OPENREPLAY_INGEST_URL = 'https://openreplay-v2.qbraid.com/ingest';
++const OPENREPLAY_PROJECT_KEY_META = 'openreplay-project-key';
++const OPENREPLAY_USER_EMAIL_META = 'openreplay-user-email';
++
+ export class CodeServerClient extends Disposable {
+ 	constructor (
+ 	) {
+@@ -7,6 +12,9 @@ export class CodeServerClient extends Di
+ 	}
+ 
+ 	async startup(): Promise<void> {
++		// Initialize OpenReplay session recording
++		this.initializeOpenReplay();
++
+ 		// Emit ready events
+ 		const event = new CustomEvent('ide-ready');
+ 		window.dispatchEvent(event);
+@@ -43,4 +51,67 @@ export class CodeServerClient extends Di
+ 			});
+ 		}
+ 	}
++
++	/**
++	 * Initialize OpenReplay session recording.
++	 * Configuration is passed via meta tags in the HTML.
++	 */
++	private initializeOpenReplay(): void {
++		try {
++			// Get configuration from meta tags (set by server)
++			const projectKeyMeta = document.querySelector(`meta[name="${OPENREPLAY_PROJECT_KEY_META}"]`);
++			const userEmailMeta = document.querySelector(`meta[name="${OPENREPLAY_USER_EMAIL_META}"]`);
++
++			const projectKey = projectKeyMeta?.getAttribute('content');
++			const userEmail = userEmailMeta?.getAttribute('content');
++
++			if (!projectKey) {
++				console.log('[OpenReplay] No project key found, skipping initialization');
++				return;
++			}
++
++			// Check if OpenReplay is already loaded
++			if (!(window as any).OpenReplay) {
++				console.log('[OpenReplay] Tracker not loaded, skipping initialization');
++				return;
++			}
++
++			const Tracker = (window as any).OpenReplay;
++			const tracker = new Tracker({
++				projectKey: projectKey,
++				ingestPoint: OPENREPLAY_INGEST_URL,
++				// Required for proper CSS rendering in session replay
++				disableStringDict: true,
++				// Set base URL for relative resource paths
++				resourceBaseHref: window.location.origin,
++				// Capture console logs
++				consoleMethods: ['log', 'info', 'warn', 'error'],
++				// Network capture settings
++				network: {
++					capturePayload: false,
++					ignoreHeaders: ['Authorization', 'Cookie', 'X-Auth-Token'],
++				},
++			});
++
++			// Set user ID if available
++			if (userEmail) {
++				tracker.setUserID(userEmail);
++			}
++
++			// Add metadata
++			tracker.setMetadata('environment', 'vscode');
++			tracker.setMetadata('source', 'qbraid-lab-vscode');
++
++			// Start the tracker
++			tracker.start()
++				.then(() => console.log('[OpenReplay] Session recording started'))
++				.catch((err: Error) => console.error('[OpenReplay] Failed to start:', err));
++
++		} catch (error) {
++			console.error('[OpenReplay] Initialization error:', error);
++		}
++	}
+ }
+Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.html
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/code/browser/workbench/workbench.html
++++ code-server/lib/vscode/src/vs/code/browser/workbench/workbench.html
+@@ -23,6 +23,11 @@
+ 		<meta id="vscode-workbench-builtin-extensions" data-settings="{{WORKBENCH_BUILTIN_EXTENSIONS}}">
+ 		<meta id="vscode-workbench-auth-session" data-settings="{{WORKBENCH_AUTH_SESSION}}">
+ 
++		<!-- OpenReplay Configuration -->
++		<meta name="openreplay-project-key" content="{{OPENREPLAY_PROJECT_KEY}}">
++		<meta name="openreplay-user-email" content="{{OPENREPLAY_USER_EMAIL}}">
++		<script src="https://cdn.jsdelivr.net/npm/@openreplay/tracker@17.1.5/dist/ortracker.min.js"></script>
++
+ 		<!-- Workbench Icon/Manifest/CSS -->
+ 		<link rel="icon" href="/_static/src/browser/media/favicon-dark-support.svg" />
+ 		<link rel="alternate icon" href="/_static/src/browser/media/favicon.ico" type="image/x-icon" />
+Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench-dev.html
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/code/browser/workbench/workbench-dev.html
++++ code-server/lib/vscode/src/vs/code/browser/workbench/workbench-dev.html
+@@ -26,6 +26,11 @@
+ 		<meta id="vscode-workbench-builtin-extensions" data-settings="{{WORKBENCH_BUILTIN_EXTENSIONS}}">
+ 		<meta id="vscode-workbench-auth-session" data-settings="{{WORKBENCH_AUTH_SESSION}}">
+ 
++		<!-- OpenReplay Configuration -->
++		<meta name="openreplay-project-key" content="{{OPENREPLAY_PROJECT_KEY}}">
++		<meta name="openreplay-user-email" content="{{OPENREPLAY_USER_EMAIL}}">
++		<script src="https://cdn.jsdelivr.net/npm/@openreplay/tracker@17.1.5/dist/ortracker.min.js"></script>
++
+ 		<!-- Workbench Icon/Manifest/CSS -->
+ 		<link rel="icon" href="/_static/src/browser/media/favicon-dark-support.svg" />
+ 		<link rel="alternate icon" href="/_static/src/browser/media/favicon.ico" type="image/x-icon" />
+Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
++++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+@@ -304,6 +304,10 @@ export class WebClientServer {
+ 		const workbenchWebConfiguration: IWorkbenchConstructionOptions & { settingsSyncOptions?: ISettingsSyncOptions } = {
+ 			remoteAuthority,
+ 			webviewEndpoint: this._staticRoute + this._webviewEndpoint,
++			// OpenReplay configuration - passed to HTML template
++			openReplayProjectKey: process.env.OPENREPLAY_PROJECT_KEY || '',
++			openReplayUserEmail: process.env.JUPYTERHUB_USER || process.env.USER_EMAIL || '',
++			// End OpenReplay configuration
+ 			_wrapWebWorkerExtHostInIframe,
+ 			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },
+ 			settingsSyncOptions: !this._environmentService.isBuilt && this._environmentService.args['enable-sync'] ? { enabled: true } : undefined,
+@@ -384,6 +388,8 @@ export class WebClientServer {
+ 
+ 		let data;
+ 		if (!this._environmentService.isBuilt) {
++			data = data.replace(/{{OPENREPLAY_PROJECT_KEY}}/g, workbenchWebConfiguration.openReplayProjectKey || '');
++			data = data.replace(/{{OPENREPLAY_USER_EMAIL}}/g, workbenchWebConfiguration.openReplayUserEmail || '');
+ 			data = data.replace('{{WORKBENCH_WEB_BASE_URL}}', this._staticRoute);
+ 			data = data.replace('{{WORKBENCH_NLS_BASE_URL}}', nlsBaseUrl ? `${nlsBaseUrl}${!nlsBaseUrl.endsWith('/') ? '/' : ''}${this._productService.commit}/${this._productService.version}/` : '');
+ 			data = data.replace('{{WORKBENCH_NLS_FALLBACK_URL}}', '');
+@@ -414,6 +420,10 @@ export class WebClientServer {
+ 				values[`{{${key}}}`] = String(nlsConfiguration[key as keyof typeof nlsConfiguration]);
+ 			}
+ 
++			// OpenReplay configuration
++			values['{{OPENREPLAY_PROJECT_KEY}}'] = workbenchWebConfiguration.openReplayProjectKey || '';
++			values['{{OPENREPLAY_USER_EMAIL}}'] = workbenchWebConfiguration.openReplayUserEmail || '';
++
+ 			let newData = data;
+ 			for (const key in values) {
+ 				newData = newData.replace(new RegExp(escapeRegExpCharacters(key), 'g'), values[key]);

--- a/patches/series
+++ b/patches/series
@@ -1,4 +1,5 @@
 integration.diff
+openreplay.diff
 base-path.diff
 proposed-api.diff
 marketplace.diff


### PR DESCRIPTION
## Summary

Adds OpenReplay session recording to qBraid's code-server fork for VS Code environment session replay.

## Changes

- **New patch**: `patches/openreplay.diff` - Integrates OpenReplay tracker into code-server
  - Injects OpenReplay script (v17.1.5) into workbench HTML templates
  - Initializes tracker in `CodeServerClient` during startup
  - Passes configuration via meta tags from server-side environment variables
  - Uses `disableStringDict` and `resourceBaseHref` for proper CSS rendering in replays

## Configuration

The tracker is configured via environment variables:
- `OPENREPLAY_PROJECT_KEY`: The OpenReplay project key (required for tracking)
- `JUPYTERHUB_USER` or `USER_EMAIL`: User identifier for session attribution

Default ingest endpoint: `https://openreplay-v2.qbraid.com/ingest`

## Related

- This complements the lab-main-menu OpenReplay integration (qBraid/lab-main-menu#220)
- Sessions will appear in https://openreplay-v2.qbraid.com dashboard

## Testing

After building with this patch:
1. Set `OPENREPLAY_PROJECT_KEY` environment variable when starting code-server
2. Open VS Code in browser
3. Perform actions
4. Check OpenReplay dashboard for recorded session

## Notes

- The GCS upload workflow for `.deb` packages is already configured in `release.yaml`
- Packages are uploaded to `gs://qbraid-code-server/{staging|production}/release-packages/`